### PR TITLE
Feat: Issue 페이지 프로토타입 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,4 +13,9 @@ module.exports = {
     'no-unused-vars': 'warn',
     'react/jsx-filename-extension': ['error', { extensions: ['.jsx'] }],
   },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
 };

--- a/src/hooks/useIssues.js
+++ b/src/hooks/useIssues.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-function useSearch() {
+function useIssues() {
   const getIssues = async (owner, repo) => {
     try {
       const res = await axios.get(
@@ -46,4 +46,4 @@ function useSearch() {
   return [getIssues, getTime];
 }
 
-export default useSearch;
+export default useIssues;

--- a/src/hooks/useIssues.js
+++ b/src/hooks/useIssues.js
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+function useSearch() {
+  const getIssues = async (owner, repo) => {
+    try {
+      const res = await axios.get(
+        `https://api.github.com/repos/${owner}/${repo}/issues`,
+        {
+          headers: { Accept: 'application/vnd.github.v3+json' },
+          params: {
+            per_page: 10,
+          },
+        },
+      );
+      console.log(res.data);
+      return res.data;
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const getTime = (createdAt) => {
+    const now = new Date();
+    const created = new Date(createdAt);
+    const timeMinutes = Math.floor(
+      (now.getTime() - created.getTime()) / 1000 / 60,
+    );
+    const timeHours = Math.floor(timeMinutes / 60);
+    const timeDays = Math.floor(timeMinutes / 60 / 24);
+
+    if (timeMinutes < 1) {
+      return '방금전';
+    }
+    if (timeMinutes < 60) {
+      return `${timeMinutes}분전`;
+    }
+    if (timeHours < 24) {
+      return `${timeHours}시간 전`;
+    }
+    if (timeDays < 365) {
+      return `${timeDays}일전`;
+    }
+    return `${Math.floor(timeDays / 365)}년 전`;
+  };
+
+  return [getIssues, getTime];
+}
+
+export default useSearch;

--- a/src/screens/Issue.jsx
+++ b/src/screens/Issue.jsx
@@ -12,28 +12,27 @@ export default function IssueScreen() {
 
   return (
     <ScrollView>
-      {issueList &&
-        issueList.map((issue) => (
-          <Link key={issue.id} href={issue.html_url}>
-            <VStack
-              bg="white"
-              flex={1}
-              my="1.5"
-              h="16"
-              display="flex"
-              justifyContent="center"
-              rounded="md"
-              shadow="3"
-              px="3"
-            >
-              <Text numberOfLines={1}>{issue.title}</Text>
-              <Text numberOfLines={1} color="primary.700">
-                {issue.user.login}
-              </Text>
-              <Text>{getTime(issue.created_at)}</Text>
-            </VStack>
-          </Link>
-        ))}
+      {issueList?.map((issue) => (
+        <Link key={issue.id} href={issue.html_url}>
+          <VStack
+            bg="white"
+            flex={1}
+            my="1.5"
+            h="16"
+            display="flex"
+            justifyContent="center"
+            rounded="md"
+            shadow="3"
+            px="3"
+          >
+            <Text numberOfLines={1}>{issue.title}</Text>
+            <Text numberOfLines={1} color="primary.700">
+              {issue.user.login}
+            </Text>
+            <Text>{getTime(issue.created_at)}</Text>
+          </VStack>
+        </Link>
+      ))}
     </ScrollView>
   );
 }

--- a/src/screens/Issue.jsx
+++ b/src/screens/Issue.jsx
@@ -1,10 +1,39 @@
-import { View } from 'native-base';
-import { Text } from 'react-native';
+import { ScrollView, Link, Text, VStack } from 'native-base';
+import { useEffect, useState } from 'react';
+import useIssues from '../hooks/useIssues';
 
 export default function IssueScreen() {
+  const [getIssues, getTime] = useIssues();
+  const [issueList, setIssueList] = useState([]);
+
+  useEffect(() => {
+    getIssues('mui', 'material-ui').then(setIssueList);
+  }, [getIssues]);
+
   return (
-    <View>
-      <Text>IssueScreen</Text>
-    </View>
+    <ScrollView>
+      {issueList &&
+        issueList.map((issue) => (
+          <Link key={issue.id} href={issue.html_url}>
+            <VStack
+              bg="white"
+              flex={1}
+              my="1.5"
+              h="16"
+              display="flex"
+              justifyContent="center"
+              rounded="md"
+              shadow="3"
+              px="3"
+            >
+              <Text numberOfLines={1}>{issue.title}</Text>
+              <Text numberOfLines={1} color="primary.700">
+                {issue.user.login}
+              </Text>
+              <Text>{getTime(issue.created_at)}</Text>
+            </VStack>
+          </Link>
+        ))}
+    </ScrollView>
   );
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev <- feature/issue-page

### 변경 사항
- useIssues 커스텀 훅 작성
  - getIssues() : repo(repository name), owner를 인자로 넘겨주면 해당 레포지토리의 issue 리스트를 받아옴
  - getTime() : issue가 생성된 date(issue.created_at)를 넘겨주면 "방금 전", "1시간 전", "3일 전"과 같이 변환해주는 함수

- Issue Page UI 구현
  - issue page 기본적인 UI를 구현했습니다. 

### 테스트 결과
![](https://cdn.discordapp.com/attachments/948964152586674217/948964760790110239/2022-03-04_12.26.51.png)

### Issue
.

### Comment
@Lee-ye-ji 님이 담당하신 작업인데 제가 맡은 검색 페이지와 구현 방법이 거의 비슷해서 
제가 기본적인 틀만 작업해봤습니다. 
남은 부분은 예지님이 이어서 작업해주시기로 했어요. 

현재 이슈리스트를 가져오는 레포를 하드코딩하고 있어서, 
myRepoList를 통해 이슈 리스트를 제대로 가져오는 작업을 해야하고 
페이지네이션도 추가되어야 합니다.
컴포넌트 분리나 최적화 작업이 되어있지 않은 상태입니다. 

