### PR TITLE
Fix/pagination

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,7 +1,7 @@
-import { Box, Button, HStack, Icon } from 'native-base';
-import PropTypes from 'prop-types';
-import { useRef } from 'react';
+import { Box, Button, HStack, Icon, Text } from 'native-base';
+import PropTypes, { number } from 'prop-types';
 import Octicons from 'react-native-vector-icons/Octicons';
+import { TouchableOpacity } from 'react-native';
 
 function ChevronButton({ type, disabled, onPress }) {
   return (
@@ -28,13 +28,21 @@ ChevronButton.propTypes = {
   type: PropTypes.oneOf(['left', 'right']),
 };
 
+const getPageLength = ({ currentPage, pageLimit, numberOfPages }) => {
+  const pageGroupNum = Math.ceil(currentPage / pageLimit);
+  const lastPageNum = pageGroupNum * pageLimit;
+  return numberOfPages > lastPageNum ? pageLimit : numberOfPages % pageLimit;
+};
+
 export default function Pagination({
   numberOfPages,
   currentPage,
+  pageLimit,
   onChange = () => undefined,
 }) {
-  const pages = useRef([...Array(numberOfPages + 1).keys()].slice(1));
-
+  const startpageNo =
+    parseInt((currentPage - 1) / pageLimit, 10) * pageLimit + 1;
+  const pageLength = getPageLength({ currentPage, pageLimit, numberOfPages });
   return (
     <HStack
       alignItems="center"
@@ -48,21 +56,29 @@ export default function Pagination({
         disabled={currentPage <= 1}
         onPress={() => onChange(currentPage - 1)}
       />
-      <Box>
-        <HStack>
-          {pages.current.map((pageNo) => (
-            <Button
-              key={pageNo}
-              bg="transparent"
-              _pressed={{ backgroundColor: 'transparent' }}
-              onPress={() => onChange(pageNo)}
-            >
-              <Octicons
-                size={15}
-                name={currentPage === pageNo ? 'square-fill' : 'square'}
-              />
-            </Button>
-          ))}
+      <Box flex={1}>
+        <HStack justifyContent="center">
+          {Array(pageLength)
+            .fill()
+            .map((_, index) => (
+              <TouchableOpacity
+                key={index}
+                bg="transparent"
+                _pressed={{ backgroundColor: 'transparent' }}
+                onPress={() => onChange(index + startpageNo)}
+                style={{ width: `${100 / pageLimit}%` }}
+              >
+                <Octicons
+                  size={15}
+                  style={{ textAlign: 'center' }}
+                  name={
+                    (currentPage - 1) % pageLimit === index
+                      ? 'square-fill'
+                      : 'square'
+                  }
+                />
+              </TouchableOpacity>
+            ))}
         </HStack>
       </Box>
 
@@ -78,5 +94,6 @@ export default function Pagination({
 Pagination.propTypes = {
   currentPage: PropTypes.number,
   numberOfPages: PropTypes.number,
+  pageLimit: PropTypes.number,
   onChange: PropTypes.func,
 };

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,7 +1,7 @@
-import { Box, Button, HStack, Icon } from 'native-base';
+import { Box, Button, HStack, Icon, Text } from 'native-base';
 import PropTypes from 'prop-types';
-import { useRef } from 'react';
 import Octicons from 'react-native-vector-icons/Octicons';
+import { TouchableOpacity } from 'react-native';
 
 function ChevronButton({ type, disabled, onPress }) {
   return (
@@ -28,13 +28,22 @@ ChevronButton.propTypes = {
   type: PropTypes.oneOf(['left', 'right']),
 };
 
+const getPageLength = ({ currentPage, pageLimit, numberOfPages }) => {
+  const pageGroupNum = Math.ceil(currentPage / pageLimit);
+  const lastPageNum = pageGroupNum * pageLimit;
+  return numberOfPages > lastPageNum ? pageLimit : numberOfPages % pageLimit;
+};
+
 export default function Pagination({
   numberOfPages,
   currentPage,
+  pageLimit,
   onChange = () => undefined,
 }) {
-  const pages = useRef([...Array(numberOfPages + 1).keys()].slice(1));
-
+  const startpageNo =
+    parseInt((currentPage - 1) / pageLimit, 10) * pageLimit + 1;
+  const pageLength = getPageLength({ currentPage, pageLimit, numberOfPages });
+  console.log(`${100 / pageLimit}%`);
   return (
     <HStack
       alignItems="center"
@@ -48,21 +57,29 @@ export default function Pagination({
         disabled={currentPage <= 1}
         onPress={() => onChange(currentPage - 1)}
       />
-      <Box>
-        <HStack>
-          {pages.current.map((pageNo) => (
-            <Button
-              key={pageNo}
-              bg="transparent"
-              _pressed={{ backgroundColor: 'transparent' }}
-              onPress={() => onChange(pageNo)}
-            >
-              <Octicons
-                size={15}
-                name={currentPage === pageNo ? 'square-fill' : 'square'}
-              />
-            </Button>
-          ))}
+      <Box flex={1}>
+        <HStack justifyContent="center">
+          {Array(pageLength)
+            .fill()
+            .map((_, index) => (
+              <TouchableOpacity
+                key={index}
+                bg="transparent"
+                _pressed={{ backgroundColor: 'transparent' }}
+                onPress={() => onChange(index + startpageNo)}
+                style={{ width: `${100 / pageLimit}%` }}
+              >
+                <Octicons
+                  size={15}
+                  style={{ textAlign: 'center' }}
+                  name={
+                    (currentPage - 1) % pageLimit === index
+                      ? 'square-fill'
+                      : 'square'
+                  }
+                />
+              </TouchableOpacity>
+            ))}
         </HStack>
       </Box>
 
@@ -78,5 +95,6 @@ export default function Pagination({
 Pagination.propTypes = {
   currentPage: PropTypes.number,
   numberOfPages: PropTypes.number,
+  pageLimit: PropTypes.number,
   onChange: PropTypes.func,
 };

--- a/src/components/PaginationList.jsx
+++ b/src/components/PaginationList.jsx
@@ -9,6 +9,7 @@ export default function PaginationList({
   onChange = () => undefined,
   data,
   renderItem,
+  pageLimit,
 }) {
   return (
     <FlatList
@@ -17,6 +18,7 @@ export default function PaginationList({
         <Pagination
           numberOfPages={numberOfPages}
           currentPage={currentPage}
+          pageLimit={pageLimit}
           onChange={onChange}
         />
       }
@@ -33,4 +35,5 @@ PaginationList.propTypes = {
   onChange: PropTypes.func,
   data: PropTypes.array.isRequired,
   renderItem: PropTypes.func.isRequired,
+  pageLimit: PropTypes.number,
 };

--- a/src/components/SearchResult.jsx
+++ b/src/components/SearchResult.jsx
@@ -6,13 +6,15 @@ import LoadingSkeleton from './LoadingSkeleton';
 import useSearch from '../hooks/useSearch';
 import PropTypes from 'prop-types';
 import useRepositoryStorage from '../hooks/useRepositoryStorage';
-import { NUMBER_OF_PAGES } from '../constants/repository';
+import { NUMBER_OF_PAGES, PER_PAGE } from '../constants/repository';
 
 const SearchResult = ({ keyword }) => {
   const [page, setPage] = useState(1);
-  const { searchResult, isLoading, isError } = useSearch(keyword, page);
+  const { searchResult, totalCount, isLoading, isError } = useSearch(
+    keyword,
+    page,
+  );
   const { addRepo } = useRepositoryStorage();
-
   if (isError) {
     return (
       <Center flex={1}>
@@ -34,12 +36,14 @@ const SearchResult = ({ keyword }) => {
       </Center>
     );
   }
+  const maxPageNum = Math.ceil(totalCount / PER_PAGE);
 
   return (
     <PaginationList
       data={searchResult}
       currentPage={page}
-      numberOfPages={NUMBER_OF_PAGES}
+      numberOfPages={maxPageNum}
+      pageLimit={NUMBER_OF_PAGES}
       onChange={setPage}
       renderItem={(repo) => (
         <RepoCard

--- a/src/constants/repository.js
+++ b/src/constants/repository.js
@@ -2,3 +2,4 @@ export const ASYNC_STORAGE_KEY = 'favorite_repository';
 export const STORED_DATA_MAX = 4;
 export const PER_PAGE = 10;
 export const NUMBER_OF_PAGES = 10;
+export const ISSUE_PAGE_LENGTH = 5;

--- a/src/hooks/useIssues.js
+++ b/src/hooks/useIssues.js
@@ -17,18 +17,23 @@ const extractIssueData = ({
 });
 
 const fetchIssues = async (repos) => {
-  if (!repos) {
-    return null;
+  try {
+    if (!repos) {
+      return null;
+    }
+    const promises = repos.map((repo) =>
+      api.get(`repos/${repo.full_name}/issues`).then((res) => res.data),
+    );
+    const responses = await Promise.all(promises);
+    const list = responses.flat().map(extractIssueData);
+    list.sort((a, b) => {
+      return new Date(b.created_at) - new Date(a.created_at);
+    });
+    return list;
+  } catch (e) {
+    console.log(e);
+    throw new Error(e);
   }
-  const promises = repos.map((repo) =>
-    api.get(`repos/${repo.full_name}/issues`).then((res) => res.data),
-  );
-  const responses = await Promise.all(promises);
-  const list = responses.flat().map(extractIssueData);
-  list.sort((a, b) => {
-    return new Date(b.created_at) - new Date(a.created_at);
-  });
-  return list;
 };
 
 function useIssues() {

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -11,10 +11,10 @@ const fetchSearchResult = async (url, keyword, pageNum) => {
         page: pageNum,
       },
     });
-    return res?.data?.items;
+    return { data: res?.data?.items, totalCount: res?.data?.total_count };
   } catch (e) {
     console.log(e);
-    return null;
+    throw new Error(e);
   }
 };
 
@@ -23,7 +23,12 @@ function useSearch(keyword, pageNum = 1) {
     ['search/repositories', keyword, pageNum],
     fetchSearchResult,
   );
-  return { searchResult: data, isLoading: !data && !error, isError: error };
+  return {
+    searchResult: data?.data,
+    totalCount: data?.totalCount,
+    isLoading: !data && !error,
+    isError: error,
+  };
 }
 
 export default useSearch;

--- a/src/screens/Issue.jsx
+++ b/src/screens/Issue.jsx
@@ -6,7 +6,7 @@ import useIssues from '../hooks/useIssues';
 import { Center, Heading } from 'native-base';
 import LoadingSkeleton from '../components/LoadingSkeleton';
 import { useState } from 'react';
-import { PER_PAGE, NUMBER_OF_PAGES } from '../constants/repository';
+import { PER_PAGE, ISSUE_PAGE_LENGTH } from '../constants/repository';
 
 export default function IssueScreen() {
   const [page, setPage] = useState(1);
@@ -22,18 +22,26 @@ export default function IssueScreen() {
       </Center>
     );
   }
-
   if (isLoading) {
     return <LoadingSkeleton />;
   }
 
+  if (issues.length === 0) {
+    return (
+      <Center flex={1}>
+        <Heading color="gray.400">{"There's no issue!"}</Heading>
+      </Center>
+    );
+  }
+  const maxPageNum = Math.ceil(issues.length / PER_PAGE);
   return (
     <MainLayout>
       <Header>Explore Issues</Header>
       <PaginationList
-        data={issues.slice(page - 1, page + (PER_PAGE - 1))}
+        data={issues.slice((page - 1) * PER_PAGE, PER_PAGE * page)}
         currentPage={page}
-        numberOfPages={NUMBER_OF_PAGES}
+        numberOfPages={maxPageNum}
+        pageLimit={ISSUE_PAGE_LENGTH}
         onChange={setPage}
         renderItem={(issue) => (
           <IssueCard


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev <- fix/pagination
### 변경 사항
1. 디바이스 화면에서 페이지네이션 영역이 넘치는 문제 존재 > 페이지네이션 버튼 레이아웃에 반응형 적용
- 기존 `<Button>`은 style 수정이 안된다고 해서 `<TouchableOpacity>`로 컴포넌트 변경 
2. 페이지네이션 10페이지 이상 넘어가지 않는 문제 
최대 페이지 수 계산하여 전달 (`numberOfpages={maxPageNum}`)
저장소 검색은 10개 issue는 5 페이지씩 뜨도록 `pageLimit` props 추가
항상 10개/5개씩 보여주는 것이 아닌 남은 페이지 만큼 보여주도록 수정(`getPageLength`)
3. 페이지네이션에 따라 data slice 시 start, end index 수정
### 테스트 결과

### Issue
- 잦은 저장소 검색시 403 오류 발생. 기다리다보면 결과가 나타나는 경우도 있음(현재는 throw error해서 error로 판단하도록 함)
- #25 의 4번째 문제는 미해결.
- 내비게이션 버튼 클릭시 페이지네이션의 현재 페이지 초기화필요

테스트하면서 우선적으로 해결이 가능한 이슈들만 해결했습니다.
이슈 페이지 페이지네이션은 좀 더 고민이 필요할 것 같습니다.
기존 페이지네이션 코드에서 수정한 부분이 있기때문에 검토해보시고 의도와 다른 부분이나 잘못된 부분 말씀부탁드립니다.

### 테스트 화면
<img alt="테스트화면" src="https://user-images.githubusercontent.com/50618754/156882387-d62e4fb4-5240-4a0b-8ea0-e7b69460cab3.gif" width="400px"/>
resolved: #25